### PR TITLE
Whitespace fix

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,8 +1,8 @@
-<!-----------------------------------------------------
+<!-- ---------------------------------------------------
 Add here global page variables to use throughout your
 website.
 The website_* must be defined for the RSS to work
-------------------------------------------------------->
+----------------------------------------------------- -->
 @def prepath = "STATS32-2020"
 @def website_title = "STATS 32: Introduction to R for undergraduates"
 @def website_descr = "Course website"
@@ -10,12 +10,12 @@ The website_* must be defined for the RSS to work
 
 @def author = "Damian Pavlyshyn"
 
-<!-----------------------------------------------------
+<!-- ---------------------------------------------------
 Add here global latex commands to use throughout your
 pages. It can be math commands but does not need to be.
 For instance:
 * \newcommand{\phrase}{This is a long phrase to copy.}
-------------------------------------------------------->
+----------------------------------------------------- -->
 \newcommand{\R}{\mathbb R}
 \newcommand{\scal}[1]{\langle #1 \rangle}
 


### PR DESCRIPTION
Will prevent an error from happening if you ever upgrade to Franklin 0.6.15+.

(basically `<!------------` and `---------->` are not allowed anymore, the indication for comment must be separated by any non `-` character so `<!-- --------`  or `------ -->` in particular)